### PR TITLE
Add Google OAuth login and disable Base44 auth redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@radix-ui/react-toggle": "^1.1.2",
     "@radix-ui/react-toggle-group": "^1.1.2",
     "@radix-ui/react-tooltip": "^1.1.8",
+    "@react-oauth/google": "^0.11.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",

--- a/src/api/base44Client.js
+++ b/src/api/base44Client.js
@@ -3,6 +3,6 @@ import { createClient } from '@base44/sdk';
 
 // Create a client with authentication required
 export const base44 = createClient({
-  appId: "68a3bdbce030093c8efa4212", 
-  requiresAuth: true // Ensure authentication is required for all operations
+  appId: "68a3bdbce030093c8efa4212",
+  requiresAuth: false // Disable automatic authentication redirect
 });

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,0 +1,30 @@
+import { GoogleOAuthProvider, GoogleLogin } from '@react-oauth/google';
+import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
+
+export default function Login() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const token = localStorage.getItem('googleIdToken');
+    if (token) {
+      navigate('/Dashboard');
+    }
+  }, [navigate]);
+
+  const handleSuccess = credentialResponse => {
+    const token = credentialResponse.credential;
+    if (token) {
+      localStorage.setItem('googleIdToken', token);
+      navigate('/Dashboard');
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID}>
+        <GoogleLogin onSuccess={handleSuccess} onError={() => console.error('Login Failed')} />
+      </GoogleOAuthProvider>
+    </div>
+  );
+}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -22,6 +22,8 @@ import EditQuest from "./EditQuest";
 
 import BugTracker from "./BugTracker";
 
+import Login from "./Login";
+
 import { BrowserRouter as Router, Route, Routes, useLocation } from 'react-router-dom';
 
 const PAGES = {
@@ -45,9 +47,11 @@ const PAGES = {
     workspace: workspace,
     
     EditQuest: EditQuest,
-    
+
     BugTracker: BugTracker,
-    
+
+    Login: Login,
+
 }
 
 function _getCurrentPage(url) {
@@ -92,11 +96,11 @@ function PagesContent() {
                 <Route path="/GuildDetail" element={<GuildDetail />} />
                 
                 <Route path="/workspace" element={<workspace />} />
-                
+
                 <Route path="/EditQuest" element={<EditQuest />} />
-                
+
                 <Route path="/BugTracker" element={<BugTracker />} />
-                
+                <Route path="/login" element={<Login />} />
             </Routes>
         </Layout>
     );


### PR DESCRIPTION
## Summary
- Disable automatic Base44 auth redirect by setting `requiresAuth` to `false`.
- Add Google OAuth based login page storing ID token locally and redirecting to Dashboard.
- Register `/login` route in router and include dependency on `@react-oauth/google`.

## Testing
- `npm run lint` *(fails: 700 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68afaf10c724832f83063c2c710de3e9