### PR TITLE
docs: add Google OAuth setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # black-letter
+
+## Google OAuth Setup
+
+1. Install the dependencies and add the Google OAuth client library:
+
+   ```bash
+   npm install
+   npm install @react-oauth/google
+   ```
+
+2. Create a Google OAuth Client ID and configure it for the app.
+   - Copy the Client ID.
+   - Create a `.env` file in the project root with:
+
+     ```env
+     VITE_GOOGLE_CLIENT_ID=your-google-oauth-client-id
+     ```
+
+3. Start the development server:
+
+   ```bash
+   npm run dev
+   ```
+
+4. Visit `http://localhost:5173/login` to test the custom Google login.
+


### PR DESCRIPTION
## Summary
- describe how to install `@react-oauth/google`
- document OAuth client ID env variable and dev server instructions

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: 709 problems)

------
https://chatgpt.com/codex/tasks/task_e_68afb0740de0832fa0c5118afa2c5852