### PR TITLE
fix google oauth package version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 
 ## Google OAuth Setup
 
-1. Install the dependencies and add the Google OAuth client library:
+1. Install dependencies:
 
-   ```bash
-   npm install
-   npm install @react-oauth/google
-   ```
+    ```bash
+    npm install
+    ```
 
 2. Create a Google OAuth Client ID and configure it for the app.
    - Copy the Client ID.

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.2",
         "@radix-ui/react-toggle-group": "^1.1.2",
         "@radix-ui/react-tooltip": "^1.1.8",
+        "@react-oauth/google": "^0.11.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@radix-ui/react-toggle": "^1.1.2",
     "@radix-ui/react-toggle-group": "^1.1.2",
     "@radix-ui/react-tooltip": "^1.1.8",
-    "@react-oauth/google": "^0.11.2",
+    "@react-oauth/google": "^0.11.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",


### PR DESCRIPTION
## Summary
- fix @react-oauth/google dependency to a valid version
- simplify README setup steps for Google OAuth

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 709 problems (700 errors, 9 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68afac23ab20832f823d27e9eec8a6f1