### PR TITLE
feat: add local login with redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 
 ## Google OAuth Setup
 
-1. Install the dependencies and add the Google OAuth client library:
+1. Install dependencies:
 
-   ```bash
-   npm install
-   npm install @react-oauth/google
-   ```
+    ```bash
+    npm install
+    ```
 
 2. Create a Google OAuth Client ID and configure it for the app.
    - Copy the Client ID.
@@ -23,5 +22,5 @@
    npm run dev
    ```
 
-4. Visit `http://localhost:5173/login` to test the custom Google login.
+4. The app will redirect to `/login` for unauthenticated users. Create a username and password or use the Google sign-in button to access the dashboard.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.2",
         "@radix-ui/react-toggle-group": "^1.1.2",
         "@radix-ui/react-tooltip": "^1.1.8",
+        "@react-oauth/google": "^0.11.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@radix-ui/react-toggle": "^1.1.2",
     "@radix-ui/react-toggle-group": "^1.1.2",
     "@radix-ui/react-tooltip": "^1.1.8",
-    "@react-oauth/google": "^0.11.2",
+    "@react-oauth/google": "^0.11.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,13 +1,16 @@
 import { GoogleOAuthProvider, GoogleLogin } from '@react-oauth/google';
 import { useNavigate } from 'react-router-dom';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function Login() {
   const navigate = useNavigate();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
 
   useEffect(() => {
     const token = localStorage.getItem('googleIdToken');
-    if (token) {
+    const localUser = localStorage.getItem('username');
+    if (token || localUser) {
       navigate('/Dashboard');
     }
   }, [navigate]);
@@ -20,11 +23,41 @@ export default function Login() {
     }
   };
 
+  const handleSubmit = e => {
+    e.preventDefault();
+    if (username && password) {
+      localStorage.setItem('username', username);
+      navigate('/Dashboard');
+    }
+  };
+
   return (
     <div className="flex items-center justify-center min-h-screen">
-      <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID}>
-        <GoogleLogin onSuccess={handleSuccess} onError={() => console.error('Login Failed')} />
-      </GoogleOAuthProvider>
+      <div className="space-y-4">
+        <form onSubmit={handleSubmit} className="flex flex-col space-y-2">
+          <input
+            className="border p-2 rounded"
+            placeholder="Username"
+            value={username}
+            onChange={e => setUsername(e.target.value)}
+          />
+          <input
+            type="password"
+            className="border p-2 rounded"
+            placeholder="Password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+          />
+          <button type="submit" className="bg-blue-500 text-white p-2 rounded">
+            Sign In
+          </button>
+        </form>
+        <div className="flex justify-center">
+          <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID}>
+            <GoogleLogin onSuccess={handleSuccess} onError={() => console.error('Login Failed')} />
+          </GoogleOAuthProvider>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -24,7 +24,7 @@ import BugTracker from "./BugTracker";
 
 import Login from "./Login";
 
-import { BrowserRouter as Router, Route, Routes, useLocation } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Routes, useLocation, Navigate } from 'react-router-dom';
 
 const PAGES = {
     
@@ -72,35 +72,36 @@ function PagesContent() {
     const location = useLocation();
     const currentPage = _getCurrentPage(location.pathname);
     
+    const token = localStorage.getItem('googleIdToken');
+    const localUser = localStorage.getItem('username');
+
+    if (!token && !localUser && location.pathname !== '/login') {
+        return <Navigate to="/login" replace />;
+    }
+
+    if ((token || localUser) && location.pathname === '/login') {
+        return <Navigate to="/Dashboard" replace />;
+    }
+
+    if (location.pathname === '/login') {
+        return <Login />;
+    }
+
     return (
         <Layout currentPageName={currentPage}>
-            <Routes>            
-                
-                    <Route path="/" element={<Dashboard />} />
-                
-                
+            <Routes>
+                <Route path="/" element={<Dashboard />} />
                 <Route path="/Dashboard" element={<Dashboard />} />
-                
                 <Route path="/CreateQuest" element={<CreateQuest />} />
-                
                 <Route path="/QuestLogs" element={<QuestLogs />} />
-                
                 <Route path="/QuestDetail" element={<QuestDetail />} />
-                
                 <Route path="/Community" element={<Community />} />
-                
                 <Route path="/Workspace" element={<Workspace />} />
-                
                 <Route path="/Settings" element={<Settings />} />
-                
                 <Route path="/GuildDetail" element={<GuildDetail />} />
-                
                 <Route path="/workspace" element={<workspace />} />
-
                 <Route path="/EditQuest" element={<EditQuest />} />
-
                 <Route path="/BugTracker" element={<BugTracker />} />
-                <Route path="/login" element={<Login />} />
             </Routes>
         </Layout>
     );


### PR DESCRIPTION
## Summary
- add local login form with username/password and Google sign-in
- redirect unauthenticated users to `/login`
- document login flow in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 709 problems (700 errors, 9 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68afac23ab20832f823d27e9eec8a6f1