### PR TITLE
Add real-time notifications and party messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+server/node_modules/
+

--- a/quest-flow-8efa4212 (4)/package.json
+++ b/quest-flow-8efa4212 (4)/package.json
@@ -58,7 +58,8 @@
     "tailwind-merge": "^3.0.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "socket.io-client": "^4.7.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",

--- a/quest-flow-8efa4212 (4)/src/App.jsx
+++ b/quest-flow-8efa4212 (4)/src/App.jsx
@@ -1,8 +1,26 @@
 import './App.css'
 import Pages from "@/pages/index.jsx"
 import { Toaster } from "@/components/ui/toaster"
+import { useEffect } from 'react'
+import { useToast } from "@/components/ui/use-toast"
+import socket from "@/lib/socket"
 
 function App() {
+  const { toast } = useToast()
+
+  useEffect(() => {
+    socket.on('notification', n => {
+      toast({ title: 'Notification', description: n.content })
+    })
+    socket.on('partyMessage', m => {
+      toast({ title: `Party ${m.party_id}`, description: m.message })
+    })
+    return () => {
+      socket.off('notification')
+      socket.off('partyMessage')
+    }
+  }, [toast])
+
   return (
     <>
       <Pages />
@@ -11,4 +29,4 @@ function App() {
   )
 }
 
-export default App 
+export default App

--- a/quest-flow-8efa4212 (4)/src/lib/socket.js
+++ b/quest-flow-8efa4212 (4)/src/lib/socket.js
@@ -1,0 +1,5 @@
+import { io } from "socket.io-client"
+
+const socket = io(import.meta.env.VITE_API_URL || "http://localhost:3000")
+
+export default socket

--- a/server/migrations/002-realtime.sql
+++ b/server/migrations/002-realtime.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS notifications (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+  content TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS party_messages (
+  id SERIAL PRIMARY KEY,
+  party_id INTEGER NOT NULL,
+  user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  message TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/server/models/notification.js
+++ b/server/models/notification.js
@@ -1,0 +1,11 @@
+const { pool } = require('../db');
+
+async function create({ user_id, content }) {
+  const result = await pool.query(
+    'INSERT INTO notifications (user_id, content) VALUES ($1, $2) RETURNING *',
+    [user_id, content]
+  );
+  return result.rows[0];
+}
+
+module.exports = { create };

--- a/server/models/partyMessage.js
+++ b/server/models/partyMessage.js
@@ -1,0 +1,11 @@
+const { pool } = require('../db');
+
+async function create({ party_id, user_id, message }) {
+  const result = await pool.query(
+    'INSERT INTO party_messages (party_id, user_id, message) VALUES ($1, $2, $3) RETURNING *',
+    [party_id, user_id, message]
+  );
+  return result.rows[0];
+}
+
+module.exports = { create };

--- a/server/package.json
+++ b/server/package.json
@@ -17,7 +17,8 @@
     "express": "^4.18.2",
     "pg": "^8.11.1",
     "bcryptjs": "^2.4.3",
-    "jsonwebtoken": "^9.0.2"
+    "jsonwebtoken": "^9.0.2",
+    "socket.io": "^4.7.5"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/server/routes/notifications.js
+++ b/server/routes/notifications.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const router = express.Router();
+const notifications = require('../models/notification');
+const { authenticateToken } = require('../auth');
+const { getIo } = require('../socket');
+
+router.use(authenticateToken);
+
+router.post('/', async (req, res) => {
+  try {
+    const notification = await notifications.create({
+      user_id: req.user.userId,
+      content: req.body.content
+    });
+    getIo().emit('notification', notification);
+    res.status(201).json(notification);
+  } catch (err) {
+    res.status(500).json({ error: 'failed to create notification' });
+  }
+});
+
+module.exports = router;

--- a/server/routes/partyMessages.js
+++ b/server/routes/partyMessages.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const router = express.Router();
+const messages = require('../models/partyMessage');
+const { authenticateToken } = require('../auth');
+const { getIo } = require('../socket');
+
+router.use(authenticateToken);
+
+router.post('/', async (req, res) => {
+  try {
+    const msg = await messages.create({
+      party_id: req.body.party_id,
+      user_id: req.user.userId,
+      message: req.body.message
+    });
+    getIo().emit('partyMessage', msg);
+    res.status(201).json(msg);
+  } catch (err) {
+    res.status(500).json({ error: 'failed to create party message' });
+  }
+});
+
+module.exports = router;

--- a/server/socket.js
+++ b/server/socket.js
@@ -1,0 +1,19 @@
+const { Server } = require('socket.io');
+
+let io;
+
+function init(server) {
+  io = new Server(server, {
+    cors: { origin: '*' }
+  });
+  return io;
+}
+
+function getIo() {
+  if (!io) {
+    throw new Error('socket.io not initialized');
+  }
+  return io;
+}
+
+module.exports = { init, getIo };


### PR DESCRIPTION
## Summary
- set up Socket.IO server and database tables for notifications and party messages
- expose endpoints that insert records and broadcast events
- connect frontend via Socket.IO client to display notifications in real time

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: 862 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c06d168c70832fae8b540d103e460b