### PR TITLE
Add bug report management with notifications

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -15,6 +15,7 @@ const guildsRouter = require('./routes/guilds');
 const questLogsRouter = require('./routes/questLogs');
 const notificationsRouter = require('./routes/notifications');
 const partyMessagesRouter = require('./routes/partyMessages');
+const bugReportsRouter = require('./routes/bugReports');
 
 const app = express();
 app.use(cors());
@@ -107,6 +108,7 @@ app.use('/api/guilds', guildsRouter);
 app.use('/api/quest_logs', questLogsRouter);
 app.use('/api/notifications', notificationsRouter);
 app.use('/api/party_messages', partyMessagesRouter);
+app.use('/api/bug_reports', bugReportsRouter);
 
 const PORT = process.env.PORT || 3000;
 server.listen(PORT, () => {

--- a/server/migrations/003-bug-reports.sql
+++ b/server/migrations/003-bug-reports.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS bug_reports (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  title TEXT NOT NULL,
+  description TEXT,
+  status TEXT NOT NULL DEFAULT 'open',
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/server/models/bugReport.js
+++ b/server/models/bugReport.js
@@ -1,0 +1,33 @@
+const { pool } = require('../db');
+
+async function create({ user_id, title, description }) {
+  const result = await pool.query(
+    'INSERT INTO bug_reports (user_id, title, description) VALUES ($1, $2, $3) RETURNING *',
+    [user_id, title, description]
+  );
+  return result.rows[0];
+}
+
+async function list() {
+  const result = await pool.query('SELECT * FROM bug_reports ORDER BY id');
+  return result.rows;
+}
+
+async function update(id, fields) {
+  const { title, description, status } = fields;
+  const result = await pool.query(
+    'UPDATE bug_reports SET title = COALESCE($1, title), description = COALESCE($2, description), status = COALESCE($3, status) WHERE id = $4 RETURNING *',
+    [title, description, status, id]
+  );
+  return result.rows[0];
+}
+
+async function close(id) {
+  const result = await pool.query(
+    'UPDATE bug_reports SET status = $1 WHERE id = $2 RETURNING *',
+    ['closed', id]
+  );
+  return result.rows[0];
+}
+
+module.exports = { create, list, update, close };

--- a/server/routes/bugReports.js
+++ b/server/routes/bugReports.js
@@ -1,0 +1,60 @@
+const express = require('express');
+const router = express.Router();
+const bugReports = require('../models/bugReport');
+const notifications = require('../models/notification');
+const { authenticateToken } = require('../auth');
+const { getIo } = require('../socket');
+
+router.use(authenticateToken);
+
+async function notifyStatus(report) {
+  const notification = await notifications.create({
+    user_id: report.user_id,
+    content: `Bug report "${report.title}" status changed to ${report.status}`
+  });
+  getIo().emit('notification', notification);
+}
+
+router.post('/', async (req, res) => {
+  try {
+    const report = await bugReports.create({
+      user_id: req.user.userId,
+      title: req.body.title,
+      description: req.body.description
+    });
+    res.status(201).json(report);
+  } catch (err) {
+    res.status(500).json({ error: 'failed to create bug report' });
+  }
+});
+
+router.get('/', async (req, res) => {
+  const reports = await bugReports.list();
+  res.json(reports);
+});
+
+router.put('/:id', async (req, res) => {
+  try {
+    const report = await bugReports.update(req.params.id, req.body);
+    if (!report) return res.status(404).json({ error: 'not found' });
+    if (req.body.status) {
+      await notifyStatus(report);
+    }
+    res.json(report);
+  } catch (err) {
+    res.status(500).json({ error: 'failed to update bug report' });
+  }
+});
+
+router.post('/:id/close', async (req, res) => {
+  try {
+    const report = await bugReports.close(req.params.id);
+    if (!report) return res.status(404).json({ error: 'not found' });
+    await notifyStatus(report);
+    res.json(report);
+  } catch (err) {
+    res.status(500).json({ error: 'failed to close bug report' });
+  }
+});
+
+module.exports = router;

--- a/server/tests/bugReportRoutes.test.js
+++ b/server/tests/bugReportRoutes.test.js
@@ -1,0 +1,67 @@
+const { newDb } = require('pg-mem');
+const fs = require('fs');
+const path = require('path');
+const jwt = require('jsonwebtoken');
+const request = require('supertest');
+const express = require('express');
+
+// setup in-memory pg and mock
+const db = newDb();
+const pg = db.adapters.createPg();
+jest.mock('pg', () => pg);
+
+const emitMock = jest.fn();
+jest.mock('../socket', () => ({
+  getIo: () => ({ emit: emitMock })
+}));
+
+const { pool } = require('../db');
+const bugReportsRouter = require('../routes/bugReports');
+
+const app = express();
+app.use(express.json());
+app.use('/api/bug_reports', bugReportsRouter);
+
+beforeAll(async () => {
+  const sql1 = fs.readFileSync(path.join(__dirname, '../migrations/001-init.sql'), 'utf8');
+  const sql2 = fs.readFileSync(path.join(__dirname, '../migrations/002-realtime.sql'), 'utf8');
+  const sql3 = fs.readFileSync(path.join(__dirname, '../migrations/003-bug-reports.sql'), 'utf8');
+  await pool.query(sql1);
+  await pool.query(sql2);
+  await pool.query(sql3);
+  await pool.query("INSERT INTO users (email, hashed_password) VALUES ('test@example.com','x')");
+});
+
+test('bug report CRUD and notifications', async () => {
+  const token = jwt.sign({ userId: 1 }, 'secret');
+  const createRes = await request(app)
+    .post('/api/bug_reports')
+    .set('Authorization', `Bearer ${token}`)
+    .send({ title: 'Bug 1', description: 'desc' });
+  expect(createRes.status).toBe(201);
+  const id = createRes.body.id;
+
+  const listRes = await request(app)
+    .get('/api/bug_reports')
+    .set('Authorization', `Bearer ${token}`);
+  expect(listRes.body.length).toBe(1);
+
+  const updateRes = await request(app)
+    .put(`/api/bug_reports/${id}`)
+    .set('Authorization', `Bearer ${token}`)
+    .send({ status: 'in_progress' });
+  expect(updateRes.body.status).toBe('in_progress');
+
+  let notifRows = await pool.query('SELECT * FROM notifications');
+  expect(notifRows.rows.length).toBe(1);
+  expect(notifRows.rows[0].content).toMatch(/in_progress/);
+
+  const closeRes = await request(app)
+    .post(`/api/bug_reports/${id}/close`)
+    .set('Authorization', `Bearer ${token}`);
+  expect(closeRes.body.status).toBe('closed');
+
+  notifRows = await pool.query('SELECT * FROM notifications');
+  expect(notifRows.rows.length).toBe(2);
+  expect(emitMock).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add bug_reports table and model
- implement API routes for submitting, listing, updating and closing bug reports
- send notification on bug report status changes
- cover bug report flow with tests

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c06e7ef2fc832f9d9ae70d3ebb58b0