### PR TITLE
feat: add frontend environment file

### DIFF
--- a/quest-flow-8efa4212 (4)/.env
+++ b/quest-flow-8efa4212 (4)/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3000

--- a/quest-flow-8efa4212 (4)/.gitignore
+++ b/quest-flow-8efa4212 (4)/.gitignore
@@ -23,4 +23,3 @@ dist-ssr
 *.sln
 *.sw?
 
-.env


### PR DESCRIPTION
## Summary
- add default frontend `.env` with `VITE_API_URL`
- remove `.env` from frontend `.gitignore` so env file can be tracked

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 869 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68c09a60c514832f8816c2b83a09d28e